### PR TITLE
Backups shouldn't be public

### DIFF
--- a/s3_dumps/connect.py
+++ b/s3_dumps/connect.py
@@ -54,8 +54,7 @@ class s3Connect:
         try:
             buck.put_object(
                 Key=file_key,
-                Body=open(media_location, 'rb'),
-                ACL='public-read')
+                Body=open(media_location, 'rb'))
             logger.info('Uploaded file key {}.'.format(file_key))
         except Exception as e:
             logger.info('Error: ', e)


### PR DESCRIPTION
Uploading backups as public is not a secure default (who wants the backup of their entire database to be public?) and causes the uploads to fail for private buckets that are set up to block public files.